### PR TITLE
Props should override template default data

### DIFF
--- a/lib/jekyll/jolt.rb
+++ b/lib/jekyll/jolt.rb
@@ -45,9 +45,9 @@ module Jekyll
           # Source: https://gist.github.com/jgatjens/8925165
           markup.scan(Liquid::TagAttributes) do |key, value|
             if (value =~ PROPS_REGEXP) != nil
-              @attributes[key] = value
+              @props[key] = @attributes[key] = value
             else
-              @attributes[key] = Liquid::Expression.parse(value)
+              @props[key] = @attributes[key] = Liquid::Expression.parse(value)
             end
           end
         end
@@ -158,10 +158,10 @@ module Jekyll
         # https://github.com/Shopify/liquid/blob/9a7778e52c37965f7b47673da09cfb82856a6791/lib/liquid/tags/include.rb
         @context[CONTEXT_NAME] = Hash.new
 
-        # Parse and extend template's front-matter with content front-matter
-        update_attributes(get_front_matter(content))
         # Add props
         update_attributes(@props)
+        # Parse and extend template's front-matter with content front-matter
+        update_attributes(get_front_matter(content))
         # Update the template's store data
         template_store_data(@attributes)
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -19,6 +19,7 @@ require 'minitest/profile'
 require 'rspec/mocks'
 
 require 'jekyll'
+require 'jekyll/joule'
 
 Jekyll.logger = Logger.new(StringIO.new)
 
@@ -36,6 +37,15 @@ Minitest::Reporters.use! [
 
 class JekyllUnitTest < Minitest::Test
   include ::RSpec::Mocks::ExampleMethods
+
+  def setup
+    @site = Site.new(site_configuration)
+    @site.read
+    @site.generate
+    @site.render
+
+    @joule = Jekyll::Joule::Site.new(@site)
+  end
 
   def mocks_expect(*args)
     RSpec::Mocks::ExampleMethods::ExpectHost.instance_method(:expect).\

--- a/test/source/_templates/data-prop.html
+++ b/test/source/_templates/data-prop.html
@@ -2,6 +2,7 @@
 title: "Default title"
 ---
 
+<div>
 <h1>{{ template.title }}</h1>
 {{ template.content }}
-
+</div>

--- a/test/test_props.rb
+++ b/test/test_props.rb
@@ -1,0 +1,30 @@
+require 'helper'
+
+class TestProps < JekyllUnitTest
+  should 'render prop data over default template data' do
+    @joule.render(%Q[
+      {% template data-prop.html title: 'Yup' %}
+        Test content
+      {% endtemplate %}
+    ])
+
+    el = @joule.find('h1')
+
+    assert_equal(el.text, 'Yup')
+  end
+
+  should 'render Ruby object passed into prop' do
+    title = 'Yasssssssssss'
+    @site.data['test-title'] = title
+
+    @joule.render(%Q[
+      {% template data-prop.html title: site.data.test-title %}
+        Test content
+      {% endtemplate %}
+    ])
+
+    el = @joule.find('h1')
+
+    assert_equal(el.text, title)
+  end
+end

--- a/test/test_template_props.rb
+++ b/test/test_template_props.rb
@@ -1,23 +1,43 @@
 require 'helper'
 
 class TestTemplate < JekyllUnitTest
-  context "jekyll-jolt" do
-    setup do
-      @site = Site.new(site_configuration)
-      @site.read
-      @site.generate
-      @site.render
-    end
+  should "render templates with props data being passed to child templates" do
 
-    should "render templates with props data being passed to child templates" do
-      post = @site.posts.docs[22]
-      expected = <<EXPECTED
-<h1>One</h1>
-<h1>Two</h1>
-<h1>Three</h1>
-<h1>Four</h1>
-EXPECTED
-      assert_equal(expected, post.output)
-    end
+    @joule.render(%Q[
+      {% template data-prop.html
+        props.title: "Two"
+        props.heading: "Four"
+      %}
+      ---
+      title: "One"
+      ---
+      {% template data-prop.html
+        title: props.title
+        heading: props.heading
+      %}
+        {% template data-prop.html
+          props.heading: props.heading
+        %}
+          ---
+          title: "Three"
+          ---
+          {% template data-prop.html
+            title: props.heading
+          %}
+          {% endtemplate %}
+        {% endtemplate %}
+      {% endtemplate %}
+    {% endtemplate %}
+    ])
+
+    el = @joule.find('div h1')
+    el2 = @joule.find('div div h1')
+    el3 = @joule.find('div div div h1')
+    el4 = @joule.find('div div div div h1')
+
+    assert_equal(el.text, 'One')
+    assert_equal(el2.text, 'Two')
+    assert_equal(el3.text, 'Three')
+    assert_equal(el4.text, 'Four')
   end
 end


### PR DESCRIPTION
## Updates

This update prioritizes props being passed into the template (on instantiation).

**Example**

```html
{% template my-template.html title: 'Override' %}
Content
{% endtemplate %}
```

In the above example, the `title` prop will override the default `title` created in the original template.

However, attributes being passed on template instantiation still trumps all:

**Example**

```html
{% template my-template.html title: 'Override' %}
---
title: 'TRUMPS OVERRIDE'
---
Content
{% endtemplate %}
```

* `jekyll-joule` has been added for unit testing
* Tests were added for new prop prioritization